### PR TITLE
Adding Dockerfile for building cs2kz_metamod with Valve's SDK Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM registry.gitlab.steamos.cloud/steamrt/sniper/sdk
+
+# Update/Upgrade and Install Pip (for AMBuild)
+RUN set -x \
+        && apt-get update && apt-get install -y \
+        --no-install-recommends --no-install-suggests python3-pip
+
+# Install AMBuild
+RUN git clone https://github.com/alliedmodders/ambuild && pip install ./ambuild
+
+# Compile cs2kz
+RUN git clone --recurse-submodules https://github.com/zer0k-z/cs2kz_metamod.git \
+        && cd cs2kz_metamod \
+        && git submodule update --init --recursive \
+        && mkdir build \
+        && cd build \
+        && python3 ../configure.py --hl2sdk-root "../" \
+        && ambuild

--- a/README.md
+++ b/README.md
@@ -80,3 +80,13 @@ ambuild
 ``` 
 
 Note: does not work with gcc!
+
+Linux (Docker w/ Valve's Docker SDK Image):
+```
+docker build -t cs2kz_metamod_build .
+docker create --name cs2kz_metamod_build cs2kz_metamod_build
+docker cp cs2kz_metamod_build:/cs2kz_metamod/build/package .
+docker rm cs2kz_metamod_build
+```
+
+Copy the contents of `package/` to your server's `csgo/` directory.

--- a/README.md
+++ b/README.md
@@ -29,10 +29,11 @@ KZ-specific:
 	- [x] Add ladder checkpoints
 - [x] Timers
 	- [x] Trigger touching logic
-- [ ] *Jumpstats*
+- [x] *Jumpstats*
 	- [x] Distbug
 	- [x] Split jump types
- 	- [ ] *Console print*
+ 	- [x] *Console print*
+  	- [ ] Invalidate various scenarios
 - [ ] HUD
 	- [x] Speed panel
  		- [x] Add prespeed and keys

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-WIP
+WIP, project is **not ready** for release
 
 Most utils stuff is based on [CS2Fixes](https://github.com/Source2ZE/CS2Fixes/)
 
@@ -15,7 +15,7 @@ KZ-specific:
 	- [x] Extends MovementPlayer to KZPlayer
 	- [x] Add MovementAPI stuff with callback registering for KZ modules
 	- [x] Disable player collisions
-	- [ ] Player transparency
+	- [ ] Player transparency (not implemented, looks ugly)
 	- [x] Make players invincible
 - [ ] Gameplay
 	- [ ] Add MOD (requires finished CVar RE)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ KZ-specific:
 - [x] Checkpoints
 	- [x] Add basic checkpoints
 	- [x] Add ladder checkpoints
-- [ ] Timers
+- [x] Timers
 	- [x] Trigger touching logic
 - [ ] *Jumpstats*
 	- [x] Distbug


### PR DESCRIPTION
- Added Dockerfile for building cs2kz_metamod using Valve's SDK Docker Image
- Updated README with instructions on how to build