### PR TITLE
ADD: better workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,10 +1,14 @@
-name: Build and Release
+name: Build
 
 on:
-  workflow_dispatch:
   workflow_call:
-  pull_request:
-  push:
+    inputs:
+      version:
+        required: false
+        type: string
+
+env:
+  VERSION_STRING: ${{ inputs.version }}
 
 jobs:
   build-linux:
@@ -12,14 +16,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: true
 
-      - name: Clone submodules
-        run: git submodule update --init --recursive
+      - name: Fetch tags
+        run: git fetch --prune --unshallow --tags
 
-      - name: Build and run Docker image
+      - name: Make build directory
+        run: mkdir ./build
+
+      - name: Build and save Docker image
         run: |
           docker build . --file Dockerfile --tag cs2kz-linux-builder
-          docker run -v ./build:/app/build cs2kz-linux-builder
+          docker run -v ./build:/app/build -v ./.git:/app/.git -e VERSION_STRING="$VERSION_STRING" cs2kz-linux-builder
 
       - name: Archive build
         uses: actions/upload-artifact@v3
@@ -32,9 +41,11 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: true
 
-      - name: Clone submodules
-        run: git submodule update --init --recursive
+      - name: Fetch tags
+        run: git fetch --prune --unshallow --tags
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -63,107 +74,12 @@ jobs:
 
       - name: Run AMBuild
         working-directory: build
-        run: ambuild
+        run: |
+          set VERSION_STRING="$VERSION_STRING"
+          ambuild
 
       - name: Archive build
         uses: actions/upload-artifact@v3
         with:
           name: cs2kz-windows
           path: ./build/package
-
-  release:
-    name: Release
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    needs:
-      - build-linux
-      - build-windows
-    steps:
-      - uses: actions/download-artifact@v3
-        with:
-          path: /home/runner/artifacts
-
-      - name: Create folders
-        run: |
-          mkdir /home/runner/releases
-
-      - name: Archive Linux build
-        run: |
-          cd /home/runner/artifacts/cs2kz-linux
-          tar -czvf /home/runner/releases/cs2kz-linux-${{ github.ref_name }}.tar.gz  .
-
-      - name: Archive Windows build
-        run: |
-          cd /home/runner/artifacts/cs2kz-windows
-          zip -r /home/runner/releases/cs2kz-windows-${{ github.ref_name }}.zip *
-
-      - name: Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            /home/runner/releases/cs2kz-linux-${{ github.ref_name }}.tar.gz
-            /home/runner/releases/cs2kz-windows-${{ github.ref_name }}.zip
-          generate_release_notes: true
-          prerelease: false
-
-  dev-release:
-    name: Dev Release
-    if: github.ref == 'refs/heads/dev'
-    runs-on: ubuntu-latest
-    needs:
-      - build-linux
-      - build-windows
-    steps:
-      - uses: actions/checkout@v3
-
-      - id: latest-release
-        uses: pozetroninc/github-action-get-latest-release@master
-        with:
-          repository: ${{ github.repository}}
-          excludes: prerelease, draft
-
-      - name: Set vars
-        id: vars
-        run: |
-          major=$(echo ${{ steps.latest-release.outputs.release }} | cut -sd 'v' -f 2 | cut -sd '.' -f 1)
-          minor=$(echo ${{ steps.latest-release.outputs.release }} | cut -sd 'v' -f 2 | cut -sd '.' -f 2)
-          patch=$(echo ${{ steps.latest-release.outputs.release }} | cut -sd 'v' -f 2 | cut -sd '.' -f 3)
-          new_patch=$(expr $number + 1)
-          short_sha=$(git rev-parse --short HEAD)
-          echo "version_string=v$major.$minor.$new_patch-dev+$short_sha" >> $GITHUB_OUTPUT
-
-      - name: Create folders
-        run: |
-          mkdir /home/runner/releases
-
-      - uses: actions/download-artifact@v3
-        with:
-          path: /home/runner/artifacts
-
-      - name: Archive Linux build
-        run: |
-          cd /home/runner/artifacts/cs2kz-linux
-          tar -czvf /home/runner/releases/cs2kz-linux-${{ steps.vars.outputs.version_string }}.tar.gz  .
-
-      - name: Archive Windows build
-        run: |
-          cd /home/runner/artifacts/cs2kz-windows
-          zip -r /home/runner/releases/cs2kz-windows-${{ steps.vars.outputs.version_string }}.zip *
-
-      - name: Tag the repository
-        id: tag
-        run: |
-          git config --global user.email "${{ github.repository_owner_id }}+${{ github.repository_owner }}@users.noreply.github.com"
-          git config --global user.name "${{ github.repository_owner }}"
-          git tag -a ${{ steps.vars.outputs.version_string }} -m "Published version ${{ steps.vars.outputs.version_string }}" ${GITHUB_SHA}
-          git push origin ${{ steps.vars.outputs.version_string }}
-
-      - name: Dev Release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ steps.vars.outputs.version_string }}
-          files: |
-            /home/runner/releases/cs2kz-linux-${{ steps.vars.outputs.version_string }}.tar.gz
-            /home/runner/releases/cs2kz-windows-${{ steps.vars.outputs.version_string }}.zip
-          generate_release_notes: false
-          prerelease: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,9 +7,6 @@ on:
         required: false
         type: string
 
-env:
-  VERSION_STRING: ${{ inputs.version }}
-
 jobs:
   build-linux:
     name: Build Linux
@@ -25,10 +22,10 @@ jobs:
       - name: Make build directory
         run: mkdir ./build
 
-      - name: Build and save Docker image
+      - name: Build and run Docker image
         run: |
           docker build . --file Dockerfile --tag cs2kz-linux-builder
-          docker run -v ./build:/app/build -v ./.git:/app/.git -e VERSION_STRING="$VERSION_STRING" cs2kz-linux-builder
+          docker run -v ./build:/app/build -v ./.git:/app/.git -e VERSION_STRING="${{ inputs.version }}" cs2kz-linux-builder
 
       - name: Archive build
         uses: actions/upload-artifact@v3
@@ -75,7 +72,7 @@ jobs:
       - name: Run AMBuild
         working-directory: build
         run: |
-          set VERSION_STRING="$VERSION_STRING"
+          set VERSION_STRING="${{ inputs.version }}"
           ambuild
 
       - name: Archive build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,15 +8,8 @@ on:
         required: true
 
 jobs:
-  test-input:
-    name: Test input
-    runs-on: ubuntu-latest
-    steps:
-      - name: Test
-        run: echo ${{ inputs.version }}
-
   build-linux:
-    name: Build Linux
+    name: Linux
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -41,7 +34,7 @@ jobs:
           path: ./build/package
 
   build-windows:
-    name: Build Windows
+    name: Windows
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,10 +4,16 @@ on:
   workflow_call:
     inputs:
       version:
-        required: false
         type: string
 
 jobs:
+  test-input:
+    name: Build Linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test
+        run: echo ${{ inputs.version }}
+
   build-linux:
     name: Build Linux
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,10 +5,11 @@ on:
     inputs:
       version:
         type: string
+        required: true
 
 jobs:
   test-input:
-    name: Build Linux
+    name: Test input
     runs-on: ubuntu-latest
     steps:
       - name: Test

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -21,14 +21,14 @@ jobs:
           echo $version
           echo "version_string=$version" >> $GITHUB_OUTPUT
     outputs:
-      version_string: "test"
+      version_string: "${{ steps.vars.outputs.version_string }}"
 
   build:
     name: Build
     needs: get-version-string
     uses: ./.github/workflows/build.yaml
     with:
-      version: ${{ needs.get-version-string.outputs.version_string }}
+      version: "test3233"
 
   dev-release:
     name: Dev Release

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -24,7 +24,7 @@ jobs:
           echo $version
           echo "version_string=$version" >> $GITHUB_OUTPUT
     outputs:
-      version_string: "${{ steps.vars.outputs.version_string }}"
+      version_string: ${{ steps.vars.outputs.version_string }}
 
   build:
     name: Build

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -9,6 +9,8 @@ jobs:
   get-version-string:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+
       - name: Set vars
         id: vars
         run: |

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -28,7 +28,7 @@ jobs:
     needs: get-version-string
     uses: ./.github/workflows/build.yaml
     with:
-      version: "${{ needs.get-version-string.outputs.version_string }}"
+      version: ${{ needs.get-version-string.outputs.version_string }}
 
   dev-release:
     name: Dev Release

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -28,7 +28,7 @@ jobs:
     needs: get-version-string
     uses: ./.github/workflows/build.yaml
     with:
-      version: "test3233"
+      version: "${{ needs.get-version-string.outputs.version_string }}"
 
   dev-release:
     name: Dev Release
@@ -38,12 +38,6 @@ jobs:
       - build
     steps:
       - uses: actions/checkout@v3
-
-      - id: latest-release
-        uses: pozetroninc/github-action-get-latest-release@master
-        with:
-          repository: ${{ github.repository}}
-          excludes: prerelease, draft
 
       - name: Create folders
         run: |

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -17,7 +17,9 @@ jobs:
           patch=$(echo ${{ github.ref_name }} | cut -sd 'v' -f 2 | cut -sd '.' -f 3)
           new_patch=$(expr $number + 1)
           short_sha=$(git rev-parse --short HEAD)
-          echo "version_string=v$major.$minor.$new_patch-dev+$short_sha" >> $GITHUB_OUTPUT
+          version=$(v$major.$minor.$new_patch-dev+$short_sha)
+          echo $version
+          echo "version_string=$version" >> $GITHUB_OUTPUT
     outputs:
       version_string: ${{ steps.vars.outputs.version_string }}
 
@@ -30,7 +32,6 @@ jobs:
 
   dev-release:
     name: Dev Release
-    if: github.ref == 'refs/heads/dev'
     runs-on: ubuntu-latest
     needs:
       - get-version-string

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -21,7 +21,7 @@ jobs:
           echo $version
           echo "version_string=$version" >> $GITHUB_OUTPUT
     outputs:
-      version_string: ${{ steps.vars.outputs.version_string }}
+      version_string: "test"
 
   build:
     name: Build

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -1,0 +1,81 @@
+name: Dev release
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  get-version-string:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set vars
+        id: vars
+        run: |
+          major=$(echo ${{ github.ref_name }} | cut -sd 'v' -f 2 | cut -sd '.' -f 1)
+          minor=$(echo ${{ github.ref_name }} | cut -sd 'v' -f 2 | cut -sd '.' -f 2)
+          patch=$(echo ${{ github.ref_name }} | cut -sd 'v' -f 2 | cut -sd '.' -f 3)
+          new_patch=$(expr $number + 1)
+          short_sha=$(git rev-parse --short HEAD)
+          echo "version_string=v$major.$minor.$new_patch-dev+$short_sha" >> $GITHUB_OUTPUT
+    outputs:
+      version_string: ${{ steps.vars.outputs.version_string }}
+
+  build:
+    name: Build
+    needs: get-version-string
+    uses: ./.github/workflows/build.yaml
+    with:
+      version: ${{ needs.get-version-string.outputs.version_string }}
+
+  dev-release:
+    name: Dev Release
+    if: github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    needs:
+      - get-version-string
+      - build
+    steps:
+      - uses: actions/checkout@v3
+
+      - id: latest-release
+        uses: pozetroninc/github-action-get-latest-release@master
+        with:
+          repository: ${{ github.repository}}
+          excludes: prerelease, draft
+
+      - name: Create folders
+        run: |
+          mkdir /home/runner/releases
+
+      - uses: actions/download-artifact@v3
+        with:
+          path: /home/runner/artifacts
+
+      - name: Archive Linux build
+        run: |
+          cd /home/runner/artifacts/cs2kz-linux
+          tar -czvf /home/runner/releases/cs2kz-linux-${{ needs.get-version-string.outputs.version_string }}.tar.gz  .
+
+      - name: Archive Windows build
+        run: |
+          cd /home/runner/artifacts/cs2kz-windows
+          zip -r /home/runner/releases/cs2kz-windows-${{ needs.get-version-string.outputs.version_string }}.zip *
+
+      - name: Tag the repository
+        id: tag
+        run: |
+          git config --global user.email "${{ github.repository_owner_id }}+${{ github.repository_owner }}@users.noreply.github.com"
+          git config --global user.name "${{ github.repository_owner }}"
+          git tag -a ${{ needs.get-version-string.outputs.version_string }} -m "Published version ${{ needs.get-version-string.outputs.version_string }}" ${GITHUB_SHA}
+          git push origin ${{ needs.get-version-string.outputs.version_string }}
+
+      - name: Dev Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ needs.get-version-string.outputs.version_string }}
+          files: |
+            /home/runner/releases/cs2kz-linux-${{ needs.get-version-string.outputs.version_string }}.tar.gz
+            /home/runner/releases/cs2kz-windows-${{ needs.get-version-string.outputs.version_string }}.zip
+          generate_release_notes: false
+          prerelease: true

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   get-version-string:
+    name: Get version string
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   get-version-string:
+    name: Get version string
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -19,7 +19,7 @@ jobs:
         run: |
           echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
     outputs:
-      short_sha: "${{ steps.vars.outputs.short_sha }}"
+      short_sha: ${{ steps.vars.outputs.short_sha }}
 
   build:
     name: Build

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -11,3 +11,5 @@ jobs:
   build:
     name: Build
     uses: ./.github/workflows/build.yaml
+    with:
+      version: ${{ github.ref_name }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -11,6 +11,8 @@ jobs:
   get-version-string:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+
       - name: Set vars
         id: vars
         run: |

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -8,8 +8,19 @@ on:
       - v*
 
 jobs:
+  get-version-string:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set vars
+        id: vars
+        run: |
+          echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+    outputs:
+      short_sha: "${{ steps.vars.outputs.short_sha }}"
+
   build:
     name: Build
     uses: ./.github/workflows/build.yaml
+    needs: get-version-string
     with:
-      version: ${{ github.ref_name }}
+      version: ${{ github.ref_name }}-${{ needs.get-version-string.outputs.short_sha }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,0 +1,13 @@
+name: Push check
+
+on:
+  push:
+    branches-ignore:
+      - dev
+    tags-ignore:
+      - v*
+
+jobs:
+  build:
+    name: Build
+    uses: ./.github/workflows/build.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   main-branch-check:
+    name: Check if main branch
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  main-branch-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Exit if not on main branch
+        if: endsWith(github.ref, 'master') == false
+        run: exit -1
+
+      - run: "echo Release build triggered by ${{ github.ref_name }}"
+
+  build:
+    name: Build
+    uses: ./.github/workflows/build.yaml
+    with:
+      version: ${{ github.ref_name }}
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          path: /home/runner/artifacts
+
+      - name: Create folders
+        run: |
+          mkdir /home/runner/releases
+
+      - name: Archive Linux build
+        run: |
+          cd /home/runner/artifacts/cs2kz-linux
+          tar -czvf /home/runner/releases/cs2kz-linux-${{ github.ref_name }}.tar.gz  .
+
+      - name: Archive Windows build
+        run: |
+          cd /home/runner/artifacts/cs2kz-windows
+          zip -r /home/runner/releases/cs2kz-windows-${{ github.ref_name }}.zip *
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            /home/runner/releases/cs2kz-linux-${{ github.ref_name }}.tar.gz
+            /home/runner/releases/cs2kz-windows-${{ github.ref_name }}.zip
+          generate_release_notes: true
+          prerelease: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - v*
 
 jobs:
   main-branch-check:
@@ -16,7 +16,7 @@ jobs:
         if: endsWith(github.ref, 'master') == false
         run: exit -1
 
-      - run: "echo Release build triggered by ${{ github.ref_name }}"
+      - run: echo Release build triggered by ${{ github.ref_name }}
 
   build:
     name: Build

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -1,13 +1,32 @@
 # vim: set sts=2 ts=8 sw=2 tw=99 et ft=python:
-import os, sys
+import os, subprocess
+
+def get_git_tag() -> str:
+  try:
+    git_cmd = ["git", "describe", "--tags", "--abbrev=0"]
+    result = subprocess.run(git_cmd, cwd="../", stdout=subprocess.PIPE)
+    git_tag_output = result.stdout.decode("utf-8").strip()
+    return git_tag_output
+  except:
+    print("Error while getting git tag.")
+    return "unknown"
 
 additional_libs = [
   # Path should be relative either to hl2sdk folder or to build folder
   #'path/to/lib/example.lib',
 ]
 
+version_string_var = os.environ.get('VERSION_STRING')
+
+if version_string_var is None or version_string_var == '':
+  version_string='VERSION_STRING="' + get_git_tag() + '"'
+else:
+  version_string='VERSION_STRING="' + version_string_var + '"'
+
+print("Version: " + version_string)
+
 additional_defines = [
-  #'EXAMPLE_DEFINE=2'
+  version_string
 ]
 
 additional_includes = [

--- a/AMBuildScript
+++ b/AMBuildScript
@@ -20,10 +20,12 @@ version_string_var = os.environ.get('VERSION_STRING')
 
 if version_string_var is None or version_string_var == '':
   version_string='VERSION_STRING="' + get_git_tag() + '"'
+  print("Got version from git tag: " + version_string)
 else:
   version_string='VERSION_STRING="' + version_string_var + '"'
+  print("Got version from env var: " + version_string_var)
 
-print("Version: " + version_string)
+print("Version string: " + version_string)
 
 additional_defines = [
   version_string

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ VOLUME /app/build
 RUN apt update && apt install -y git python3-pip
 RUN git clone https://github.com/alliedmodders/ambuild
 RUN pip install ./ambuild
+RUN git config --global --add safe.directory /app
 
 COPY . .
 CMD [ "/bin/bash", "./docker-entrypoint.sh" ]

--- a/src/cs2kz.cpp
+++ b/src/cs2kz.cpp
@@ -17,6 +17,11 @@
 #include "kz/quiet/kz_quiet.h"
 
 #include "tier0/memdbgon.h"
+
+#ifndef VERSION_STRING
+#define VERSION_STRING "v0.0.0"
+#endif
+
 KZPlugin g_KZPlugin;
 
 class GameSessionConfiguration_t { };
@@ -93,7 +98,7 @@ const char *KZPlugin::GetLicense()
 
 const char *KZPlugin::GetVersion()
 {
-	return "0.0.0.1";
+	return VERSION_STRING;
 }
 
 const char *KZPlugin::GetDate()
@@ -123,7 +128,7 @@ const char *KZPlugin::GetName()
 
 const char *KZPlugin::GetURL()
 {
-	return "https://cs2.kz/";
+	return "https://github.com/zer0k-z/cs2kz_metamod";
 }
 
 internal float Hook_ProcessUsercmds_Pre(CPlayerSlot slot, bf_read *buf, int numcmds, bool ignore, bool paused)


### PR DESCRIPTION
I've split the workflow into a reusable workflow.

I've added a VERSION_STRING env variable. If VERSION_STRING isn't set, we check the git repo for the current tag. If git doesn't work, we use "unknown." The env variable is used in the AMBuildScript to add a VERSION_STRING define.

We are able to use the variable in our workflow to set the new tag.
